### PR TITLE
Pin pytz version

### DIFF
--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -1,6 +1,6 @@
 psycopg2-binary>=2.7.3.1,<3
 aiohttp
-pytz
+pytz==2024.2
 cffi>=1.13
 backoff
 requests


### PR DESCRIPTION
This updated pytz version includes a "fix" to daylight savings time calculation (`UTC-7` vs `UTC-8`).  Lots of data in OrgBook is wrong, showing a `-8` offset vs a `-7` offset, affecting about 10,000 companies (maybe more, this is just looking at the company registration date).

At some point the BC Reg issuer was updated with a new pytz version, so the pytz versions are out f sync between the issuer and the audit, which is causing audit issues.